### PR TITLE
Change the type of FileReader.Handler from *os.File to *bytes.Reader

### DIFF
--- a/FileReader.go
+++ b/FileReader.go
@@ -1,18 +1,18 @@
 package GoIPQSDBReader
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 )
 
 type FileReader struct {
-	Handler     *os.File
+	Handler     *bytes.Reader
 	TotalBytes  uint64
 	RecordBytes uint64
 

--- a/GoIPQSDBReader.go
+++ b/GoIPQSDBReader.go
@@ -4,19 +4,13 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"os"
 )
 
 var GOLANG_IPQS_READER_VERSION = byte(1)
 
-func Open(filename string) (*FileReader, error) {
+func Open(r *bytes.Reader) (*FileReader, error) {
 	file := &FileReader{Columns: make(map[int]*Column)}
-
-	var ferr error
-	file.Handler, ferr = os.Open(filename)
-	if ferr != nil {
-		return file, ferr
-	}
+	file.Handler = r
 
 	header := make([]byte, 11)
 	bl, err := file.Handler.Read(header)


### PR DESCRIPTION
This will facilitate holding the contents in memory without large, extraneous allocations. (As mentioned elsewhere, the memfd_create(2) and mmap(2) tricks had issues.)